### PR TITLE
Remove the Parent Link from the Game Example

### DIFF
--- a/version1/games.md
+++ b/version1/games.md
@@ -124,9 +124,6 @@ Represented as JSON, a game looks like this:
     "rel": "variables",
     "uri": "http://www.speedrun.com/api/v1/games/1kgr75w4/variables"
   }, {
-    "rel": "parent",
-    "uri": "http://www.speedrun.com/api/v1/games/lkcbez17"
-  }, {
     "rel": "romhacks",
     "uri": "http://www.speedrun.com/api/v1/games/1kgr75w4/romhacks"
   }]


### PR DESCRIPTION
Due to there being Series now, the parent link was actually removed, but it was forgotten in the example. This fixes that.